### PR TITLE
Switch to using a content hash for filenames

### DIFF
--- a/packages/catalyst/src/config/webpack/generateOutput.ts
+++ b/packages/catalyst/src/config/webpack/generateOutput.ts
@@ -34,7 +34,7 @@ export default function generateOutput(): Output {
   return {
     path: buildPath,
     publicPath,
-    filename: '[name]-[hash].js',
+    filename: '[name].[contenthash:8].js',
     jsonpFunction
   };
 }


### PR DESCRIPTION
This will allow chunks to be cached for a longer period of time.